### PR TITLE
add zsh-completion

### DIFF
--- a/zsh-completion
+++ b/zsh-completion
@@ -1,0 +1,16 @@
+#compdef aurvote
+
+_aurvote() {
+  local -a options
+
+  options=('--version:shows version'
+           '--help:shows this help'
+           '--check:check for voted packages'
+           '--vote:vote for packages'
+           '--unvote:unvote packages'
+           "--configure:create $HOME/.config/aurvote")
+
+  _describe 'options' options
+}
+
+_aurvote


### PR DESCRIPTION
Also, you might want an updated PKGBUILD:

```
# Maintainer: tuxce <tuxce.net@gmail.com>
# Contributor: Thiago Perrotta <perrotta dot thiago at poli dot ufrj dot br>
pkgname=aurvote
pkgver=1.8
pkgrel=2
pkgdesc="Tool to vote for favorite AUR packages"
url="http://git.archlinux.fr/aurvote.git/"
license="GPL"
arch=('any')
depends=('curl')
source=("$pkgname"
        'zsh-completion')

package() {
    install -D -m 755 "$srcdir/$pkgname" "$pkgdir/usr/bin/$pkgname"
    install -D -m 644 "$srcdir/zsh-completion" "$pkgdir/usr/share/zsh/site-functions/_$pkgname"
}

md5sums=('1cba0a7377b8de6aec9f84b3a5491bda'
         'e158204390087d376ae49a36f37d5c4d')
```

I updated `pkgrel` because this patch is not a really version of aurvote, but feel free to do it as you wish.