### PR TITLE
check without without any arguments shows all aur packages(pacman -Qmq)

### DIFF
--- a/aurvote
+++ b/aurvote
@@ -219,7 +219,14 @@ fi
 
 COOKIE_FILE=${COOKIE_FILE:-"$AV_TMP/cookies"}
 pkgnames=("${pkgnames[@]%/*}") # compatibility with yaourt <= 1.2.1
-[[ ! $pkgnames ]] && usage && exit 1
+
+if [[ ! $pkgnames ]]; then
+    if (( ACTION=="check" )); then
+        pkgnames=($(pacman -Qmq))
+    else
+        usage && exit 1
+    fi
+fi
 
 aur_login
 

--- a/aurvote
+++ b/aurvote
@@ -221,7 +221,7 @@ COOKIE_FILE=${COOKIE_FILE:-"$AV_TMP/cookies"}
 pkgnames=("${pkgnames[@]%/*}") # compatibility with yaourt <= 1.2.1
 
 if [[ ! $pkgnames ]]; then
-    if [[ ACTION=="check" ]]; then
+    if [[ $ACTION == "check" ]]; then
         pkgnames=($(pacman -Qmq))
     else
         usage && exit 1

--- a/aurvote
+++ b/aurvote
@@ -221,7 +221,7 @@ COOKIE_FILE=${COOKIE_FILE:-"$AV_TMP/cookies"}
 pkgnames=("${pkgnames[@]%/*}") # compatibility with yaourt <= 1.2.1
 
 if [[ ! $pkgnames ]]; then
-    if (( ACTION=="check" )); then
+    if [[ ACTION=="check" ]]; then
         pkgnames=($(pacman -Qmq))
     else
         usage && exit 1


### PR DESCRIPTION
IMO it is useful to show automatically all non official packages during check if not package names have been passed.
