### PR TITLE
check shows packages that are being checked

### DIFF
--- a/aurvote
+++ b/aurvote
@@ -109,6 +109,7 @@ aur_check_vote() {
     local pkg
     for pkg in "${pkgnames[@]}"; do
         aur_get_pkg_page "$pkg"
+        echo -n "$pkg... " 
         if sed '/<div id="news">/q' "$AV_TMP/$pkg.$PID" | grep -q /unvote/; then
             echo "already voted"
         elif sed '/<div id="news">/q' "$AV_TMP/$pkg.$PID" | grep -q /vote/; then


### PR DESCRIPTION
If list of packages is too long it is useful to juxtapose the name of package with the output of the check.
